### PR TITLE
[20230525] 손영진 문제 풀이

### DIFF
--- a/ILoveGameCoding/20230525/11725.py
+++ b/ILoveGameCoding/20230525/11725.py
@@ -1,0 +1,23 @@
+import sys
+from collections import deque
+
+node_count = int(input())
+node_connections = [[] for _ in range(node_count + 1)]
+node_parents = [0] * (node_count + 1)
+
+for _ in range(node_count - 1):
+    node_1, node_2 = map(int, sys.stdin.readline().split())
+    node_connections[node_1].append(node_2)
+    node_connections[node_2].append(node_1)
+
+node_queue = deque([1])  # queue에 1번 노드 추가
+while node_queue:  # queue가 비어있지 않을 때까지
+    node = node_queue.popleft()  # queue에서 노드 하나 추출
+
+    for next_node in node_connections[node]:  # 해당 노드와 연결된 노드들을 접근
+        if not node_parents[next_node]:  # 아직 부모 노드가 없는 경우
+            node_parents[next_node] = node  # 해당 노드의 부모 노드를 현재 노드로 설정
+            node_queue.append(next_node)  # 해당 노드를 queue에 추가
+
+for idx in range(2, node_count + 1):
+    print(node_parents[idx])

--- a/ILoveGameCoding/20230525/1388.py
+++ b/ILoveGameCoding/20230525/1388.py
@@ -1,0 +1,27 @@
+height, width = map(int, input().split())
+
+floor_map = []
+
+for _ in range(height):
+    floor_map.append([char for char in input()])
+
+tile_count = 0
+
+for h_idx in range(height):
+    for w_idx in range(width):
+        if floor_map[h_idx][w_idx] == -1:
+            continue
+
+        tile_count += 1
+        if floor_map[h_idx][w_idx] == '-':
+            temp_w_idx = w_idx
+            while temp_w_idx < width and floor_map[h_idx][temp_w_idx] == '-':
+                floor_map[h_idx][temp_w_idx] = -1
+                temp_w_idx += 1
+        elif floor_map[h_idx][w_idx] == '|':
+            temp_h_idx = h_idx
+            while temp_h_idx < height and floor_map[temp_h_idx][w_idx] == '|':
+                floor_map[temp_h_idx][w_idx] = -1
+                temp_h_idx += 1
+
+print(tile_count)

--- a/ILoveGameCoding/20230525/1697.py
+++ b/ILoveGameCoding/20230525/1697.py
@@ -1,0 +1,18 @@
+from collections import deque
+
+subin_pos, brother_pos = map(int, input().split())
+
+game_map = [0] * 100001
+
+subin_pos_queue = deque([subin_pos])
+while subin_pos_queue:  # 수빈이의 위치 목록이 비어있지 않을 때까지
+    subin_pos = subin_pos_queue.popleft()  # 수빈이의 위치 하나 추출
+
+    if subin_pos == brother_pos:  # 수빈이의 위치가 동생의 위치가 같을 경우
+        print(game_map[subin_pos])  # 수빈이가 동생을 찾은 시간 출력
+        break
+
+    for subin_next_pos in [subin_pos - 1, subin_pos + 1, subin_pos * 2]:  # 수빈이의 이동할 수 있는 다음 위치 접근
+        if 0 <= subin_next_pos <= 100000 and not game_map[subin_next_pos]:  # 최소, 최대 위치를 넘지 않고 아직 방문하지 않은 위치일 경우
+            game_map[subin_next_pos] = game_map[subin_pos] + 1  # 해당 위치에 수빈이가 도달하는 시간을 저장
+            subin_pos_queue.append(subin_next_pos)  # 해당 위치를 수빈이의 위치 목록에 추가

--- a/ILoveGameCoding/20230525/2606.py
+++ b/ILoveGameCoding/20230525/2606.py
@@ -1,5 +1,9 @@
+INFECTED = True
+NOT_INFECTED = False
+
+
 def check_infected_computer(computer_connections, start_computer, checked_computers):
-    checked_computers[start_computer] = True  # 현재 컴퓨터를 확인된 컴퓨터로 표시
+    checked_computers[start_computer] = INFECTED  # 현재 컴퓨터를 확인된 컴퓨터로 표시
 
     for connected_computer in computer_connections[start_computer]:  # 연결된 컴퓨터들을 확인
         if not checked_computers[connected_computer]:  # 아직 확인되지 않은 컴퓨터일 경우
@@ -17,8 +21,8 @@ for _ in range(connection_count):
     computer_connections[computer_2].append(computer_1)
 
 # 연산 편리성을 위해 0번 인덱스는 사용하지 않고 1번부터 사용
-checked_computers = [False] * (computer_count + 1)
+checked_computers = [NOT_INFECTED] * (computer_count + 1)
 
 check_infected_computer(computer_connections, 1, checked_computers)
 
-print(checked_computers.count(True) - 1)
+print(checked_computers.count(INFECTED) - 1)

--- a/ILoveGameCoding/20230525/2606.py
+++ b/ILoveGameCoding/20230525/2606.py
@@ -1,0 +1,24 @@
+def check_infected_computer(computer_connections, start_computer, checked_computers):
+    checked_computers[start_computer] = True  # 현재 컴퓨터를 확인된 컴퓨터로 표시
+
+    for connected_computer in computer_connections[start_computer]:  # 연결된 컴퓨터들을 확인
+        if not checked_computers[connected_computer]:  # 아직 확인되지 않은 컴퓨터일 경우
+            check_infected_computer(computer_connections, connected_computer, checked_computers)
+
+
+computer_count = int(input())
+connection_count = int(input())
+
+computer_connections = [[] for _ in range(computer_count + 1)]
+
+for _ in range(connection_count):
+    computer_1, computer_2 = map(int, input().split())
+    computer_connections[computer_1].append(computer_2)
+    computer_connections[computer_2].append(computer_1)
+
+# 연산 편리성을 위해 0번 인덱스는 사용하지 않고 1번부터 사용
+checked_computers = [False] * (computer_count + 1)
+
+check_infected_computer(computer_connections, 1, checked_computers)
+
+print(checked_computers.count(True) - 1)


### PR DESCRIPTION
## 🔖 푼 문제들 
### 1. 1388 바닥 장식
1) 첫 번째 타일부터 마지막 타일까지 탐색 시작

2) 현재 타일이 '-'일 경우 우측으로 '-'이 나오지 않으면서 너비를 벗어나지 않을 때까지 탐색 => 이때 움직인 자리들은 -1로 채움

3) 현재 타일이 '|'일 경우 하단으로 '|'이 나오지 않으면서 높이를 벗어나지 않을 때까지 탐색 => 이때 움직인 자리들은 -1로 채움

4) 2~3 중 하나를 실행할 때마다 타일 개수를 하나 증가

위 과정을 거쳐서 최종적으로 모든 map이 -1로 채워지고 이렇게 채우는데 필요한 타일 개수를 구할 수 있음

<br>

### 2. 2606 바이러스
DFS 재귀
1) 각 컴퓨터들의 연결 상태를 2차원 배열 computer_connections 로 나타냄

2) 각 컴퓨터의 감염 상태를 저장하는 checked_computers 선언

3) check_infected_computer 함수에서 현재 컴퓨터를(애초에 check_infected_computer로 들어온 컴퓨터는 감염된 상태) INFECTED 상태로 지정하고 그 컴퓨터와 연결된 컴퓨터들을 computer_connections에서 가져와 INFECTED 상태가 아닐 경우 check_infected_computer 함수로 재귀 호출

4) 이러한 과정을 거치면 checked_computers에서 감염되지 않은 컴퓨터들은 NOT_INFECTED 상태로 남아있으므로 이 개수를 세고, 1번 컴퓨터에 대한 감염도 고려해야 하므로 -1을 해줌으로써 최종 네트워크를 통해 감염된 컴퓨터의 개수를 알 수 있음

<br>

### 3. 1697 숨바꼭질
BFS 
1) 수빈이가 이동하는 위치마다 걸린 시간을 저장하기 위해 game_map 일차원 배열 선언

2) 수빈이가 현재 위치에서 갈 수 있는 위치들을 queue에 저장(뒤에 append)하고, queue의 앞에서부터 하나씩 뺌

3) 만약 queue에서 뺀 위치가 동생 위치와 동일하지 않을 경우 수빈이가 현재 위치에서 다음에 이동할 수 있는 위치 (subin_pos - 1, subin_pos + 1, subin_pos x 2)에 각각에 대해서 탐색 => game_map에 해당 위치에 대한 도착 시간이 없을 경우 현재 수빈이 위치에 도달하는 시간에서 +1을 해준 값을 game_map에 저장 후 queue에 해당 위치 추가

4) 만약 queue에서 뺀 위치가 동생 위치와 동일하다면 해당 위치에 도달하는데 걸린 시간을 출력하고 종료

<br>

### 4. 11725 트리의 부모 찾기
BFS
앞서 풀었던 숨바꼭질과 동일한 구조로 품. 노드 연결 관계를 나타내기 위해 바이러스 문제와 같이 2차원 배열 node_connections를 이용.

1) 각 노드에 해당되는 부모 노드를 저장하는 node_parents 1차원 배열 선언
2) 처음에 1번부터 시작하므로 queue에 1 추가
3) queue가 비어있지 않을 때까지 탐색하고, queue에 들어와 있는 첫 번째 원소를 pop
3) pop된 원소와 연결되어 있는 노드들을 node_connections에서 가져오고 만약 node_parents 1차원 배열에 해당 노드들의 부모가 설정되어 있지 않을 경우 현재 pop한 원소를 부모 노드로 지정 및 그 노드들을 queue에 append

아 그리고 이 문제 풀 때 노드들 연결 관계 input()로 받으면 채점 엄청 느림. sys.stdin.readline()으로 하는게 훨 빠름.

<br>

## 🙏 같이 논의해보고 싶은 것 
없다잉
근데 확실히 DP 하면서 어떻게 해결해야되나 많이 생각하다보니까 알고리즘 문제들 접근하는게 좀 더 쉬워진 것 같은 느낌