### PR TITLE
[20230525] 배성준 문제 풀이

### DIFF
--- a/westofsky/20230525/11725.py
+++ b/westofsky/20230525/11725.py
@@ -1,0 +1,22 @@
+import sys
+sys.setrecursionlimit(10**6)
+T = int(sys.stdin.readline())
+graph = [[] for _ in range(T+1)]
+visited = [False] * (T+1)
+parent = [0] * (T+1)
+
+for _ in range(T-1):
+    start,end = map(int,sys.stdin.readline().split())
+    graph[start].append(end)
+    graph[end].append(start)
+for i in range(T+1):
+    graph[i].sort()
+def DFS(v):
+    visited[v] = True
+    for i in graph[v]:
+        if not visited[i]:
+            parent[i] = v
+            DFS(i)
+DFS(1)
+for i in range(2,T+1):
+    print(parent[i])

--- a/westofsky/20230525/1388.py
+++ b/westofsky/20230525/1388.py
@@ -1,0 +1,33 @@
+import sys
+
+Y,X = map(int,sys.stdin.readline().split())
+
+graph = [[False] * (X) for _ in range(Y)]
+maps = []
+answer = 0
+def checkRange(i,j):
+    return i >=0 and i < Y and j>=0 and j<X
+def DFS(i,j,t):
+    graph[i][j] = True
+    if t == '-':
+        if not checkRange(i,j+1):
+            pass
+        else:
+            if t == maps[i][j+1]:
+                DFS(i,j+1,t)
+    elif t == '|':
+        if not checkRange(i+1,j):
+            pass
+        else:
+            if t == maps[i+1][j]:
+                DFS(i+1,j,t)
+
+for i in range(Y):
+    maps.append(list(input()))
+for i in range(Y):
+    for j in range(X):
+        if not graph[i][j]: #다른 블럭에 포함이 안됐을때
+            answer += 1
+            DFS(i,j,maps[i][j])
+
+print(answer)

--- a/westofsky/20230525/2606.py
+++ b/westofsky/20230525/2606.py
@@ -1,0 +1,17 @@
+import sys
+T = int(sys.stdin.readline())
+graph = [[] for i in range(T+1)]
+visited = [False] * (T+1)
+C = int(sys.stdin.readline())
+for _ in range(C):
+    start, end = map(int,sys.stdin.readline().split())
+    graph[start].append(end)
+    graph[end].append(start)
+
+def DFS(v):
+    visited[v] = True
+    for i in graph[v]:
+        if not visited[i]:
+            DFS(i)
+DFS(1)
+print(visited.count(True)-1)

--- a/westofsky/20230622/10026.py
+++ b/westofsky/20230622/10026.py
@@ -1,0 +1,12 @@
+from collections import deque
+import sys
+T = int(sys.stdin.readline())
+maps1 = []
+maps2 = []
+
+for i in range(T):
+    inputs = sys.stdin.readline().strip()
+    maps1.append(list(inputs))
+    maps2.append(list(inputs.replace('G','R')))
+
+def dfs(x,y):

--- a/westofsky/20230622/2178.py
+++ b/westofsky/20230622/2178.py
@@ -1,0 +1,33 @@
+import sys
+from collections import deque
+answer = 0
+X,Y = map(int,sys.stdin.readline().split())
+maps = []
+for i in range(X):
+    maps.append(list(map(int,sys.stdin.readline().strip())))
+# 상하좌우
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+def bfs(x, y):
+    queue = deque()
+    queue.append((x, y))
+
+    while queue:
+        x, y = queue.popleft()
+
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+
+            if nx < 0 or nx >= len(maps) or ny < 0 or ny >= len(maps[0]): continue
+
+            if maps[nx][ny] == 0:
+                continue
+
+            if maps[nx][ny] == 1:
+                maps[nx][ny] = maps[x][y] + 1
+                queue.append((nx, ny))
+
+    return maps[len(maps)-1][len(maps[0])-1]
+print(bfs(0,0))


### PR DESCRIPTION
## 🔖 푼 문제들 
### 1. 2606 바이러스
시작 노드(1)에서 dfs나 bfs로 탐색한다음 visited한 갯수만 세는 문제

### 2. 1388 바닥 장식
처음에 두개만 합쳐서 하나의 블록인줄 알았다가 예제 보니 가능한 이을 수 있는 만큼 이은 블록이 하나이었던 것
(0,0)에서 시작해서 문자 모양('-','|')에 따라 한 방향으로 쭉 dfs 탐색해서 갯수 세는 문제

### 3. 11725 트리의 부모 찾기
그냥 dfs돌면서 dfs함수 들어가기 전에 부모를 찍고 쭉 탐색하면 되는 문제
제대로 푼 것 같은데 자꾸 런타임 오류나서 왜 그런지 [질문게시판](https://www.acmicpc.net/board/view/63655)봤다가 [sys.setrecursionlimit](https://fuzzysound.github.io/sys-setrecursionlimit) 에 대해 알고 풀었음

### 4. 1697 숨바꼭질 
이따가 풀겟습니다!



## 🙏 같이 논의해보고 싶은 것
DFS,BFS선정기준 ..? 딱히 상관없을것같지만