### PR TITLE
[20230706] 박준호 문제풀이

### DIFF
--- a/Junho Park/20230706/12015.py
+++ b/Junho Park/20230706/12015.py
@@ -1,0 +1,29 @@
+# this is my solution for BaekJoon 12015
+# 가장 긴 증가하는 부분 수열 2
+# https://www.acmicpc.net/problem/12015
+# =======================================
+# References
+# https://jainn.tistory.com/92
+# https://jainn.tistory.com/90
+
+from sys import stdin
+
+N = int(stdin.readline())
+sequence = list(map(int, stdin.readline().split()))
+arr = [0]
+
+for n in sequence:
+    if arr[-1] < n:
+        arr.append(n)
+    else:
+        left = 0
+        right = len(arr)
+        while left < right:
+            mid = (left + right)//2
+            if arr[mid] < n:
+                left = mid + 1
+            else:
+                right = mid
+        arr[right] = n
+
+print(len(arr) - 1)

--- a/Junho Park/20230706/1821.py
+++ b/Junho Park/20230706/1821.py
@@ -1,5 +1,5 @@
-# This is my solution for BaekJoon 1821 수들의 합 6
-# 
+# This is my solution for BaekJoon 1821 
+# 수들의 합 6
 # https://www.acmicpc.net/problem/1821
 
 # my initial approach

--- a/Junho Park/20230706/1821.py
+++ b/Junho Park/20230706/1821.py
@@ -1,0 +1,15 @@
+# This is my solution for BaekJoon 1821 수들의 합 6
+# 
+# https://www.acmicpc.net/problem/1821
+
+# my initial approach
+#
+# def pascal(N, F):
+#     if N == 1:
+#         return
+#     for i in range(1, F):
+#         pascal(N-1, i)
+#         pascal(N-1, F-i)
+
+N, F = map(int, input().strip().split())
+

--- a/Junho Park/20230706/2447.py
+++ b/Junho Park/20230706/2447.py
@@ -1,0 +1,30 @@
+# this is my solution for BaekJoon 2447
+# 별찍기 - 10
+# https://www.acmicpc.net/problem/2447
+
+N = int(input())
+
+stars = [['*'] * (N) for _ in range(N)]
+
+def spacing(N, x, y):
+    if N == 1:
+        return
+    for i in range(N//3, 2*(N//3)):
+        for j in range(N//3, 2*(N//3)):
+            stars[i + x][j + y] = ' '
+    spacing(N//3, x, y)                         # left top
+    spacing(N//3, N//3+x, y)                    # middle top
+    spacing(N//3, 2*(N//3)+x, y)                # right top
+    spacing(N//3, x, N//3 + y)                  # left middle
+    spacing(N//3, 2*(N//3) + x, N//3 + y)       # center
+    spacing(N//3, 2*(N//3) + x, N//3 + y)       # right middle
+    spacing(N//3, x, 2*(N//3) + y)              # left bottom
+    spacing(N//3, N//3 + x, 2*(N//3) + y)       # middle bottom
+    spacing(N//3, 2*(N//3) + x, 2*(N//3) + y)   # right bottom
+
+spacing(N, 0, 0)
+
+for i in range(N):
+    for j in range(N):
+        print(stars[i][j], end='')
+    print()

--- a/Junho Park/20230706/6236.py
+++ b/Junho Park/20230706/6236.py
@@ -1,0 +1,48 @@
+# This is my solution for BaekJoon 6236
+# 용돈 관리
+# https://www.acmicpc.net/problem/6236
+
+from sys import stdin
+
+# =================================================
+# My initial solution -> timeout
+# =================================================
+# class solution:
+#     def __init__(self):
+#         self.N, self.M = map(int, stdin.readline().split())
+#         self.money = []
+#         for _ in range(self.N):
+#             self.money.append(int(stdin.readline()))
+#         self.minMoney = min(self.money)
+#         self.maxMoney = max(self.money)
+#         self.K = self.maxMoney
+#         self.solve()
+
+#     def solve(self):
+#         wdc = self.withdrawCount()
+#         while True:
+#             if wdc == self.M:
+#                 print(self.K)
+#                 return
+#             else:
+#                 if wdc > self.M:
+#                     self.K += 1
+#                 else:
+#                     self.K -= 1
+#                 wdc = self.withdrawCount()
+    
+#     def withdrawCount(self):
+#         cnt = 0
+#         balance = 0
+#         for money in self.money:
+#             if balance < money:
+#                 cnt += 1
+#                 balance = self.K
+#             balance -= money
+#             while balance < 0:
+#                 cnt += 1
+#                 balance += self.K
+#         return cnt
+
+# sol = solution()
+

--- a/Junho Park/20230706/6236.py
+++ b/Junho Park/20230706/6236.py
@@ -46,3 +46,32 @@ from sys import stdin
 
 # sol = solution()
 
+# Reference: https://velog.io/@deannn/BOJ-%EB%B0%B1%EC%A4%80-6236-%EC%9A%A9%EB%8F%88%EA%B4%80%EB%A6%AC-Python
+
+N, M = map(int, stdin.readline().split())
+money = []  # money for each day
+for _ in range(N):
+    money.append(int(stdin.readline()))
+
+# Two pointers
+left = min(money)
+right = sum(money)
+
+while left <= right:
+    mid = (left + right) // 2   # center value, temporary K
+    balance = mid               # cashing out
+    cnt = 1                     # cashing out count
+
+    for pay in money:
+        if balance < pay:
+            balance = mid
+            cnt += 1
+        balance -= pay
+    
+    if cnt > M or mid < max(money):
+        left = mid + 1
+    else:
+        right = mid - 1
+        K = mid
+
+print(K)


### PR DESCRIPTION
## 🔖 푼 문제들 
### 1. 1821 수들의 합 6
파스칼 삼각형 공식 사용해서 풀으라고 하는데, 구글링해서 나온 코드 봐도 이해가 되질 않아서 풀이 보류 했습니다. 
처음에 재귀함수 사용해서 가장 밑에부터 숫자 대입해가며 풀으려고 했으나, 홀수 개의 정수들이 있는 층을 처리할 수 없어서 포기했습니다.

### 2. 2447 별찍기 - 10
정말 재밌게 푼 문제. 먼저 N x N의 별로 이루어진 맵을 만들고, 2623 색종이 만들기 문제처럼 분할정복 재귀 하여 풀었습니다. 

위 - 왼쪽, 가운데, 오른쪽
중앙 - 왼쪽, 오른쪽
아래 - 왼쪽, 가운데, 오른쪽

총 8번의 재귀를 하였고, 중앙에는 공백을 넣어줘서 풀었습니다.

### 3. 6236 용돈 관리
K 를 1씩 증감하며 찾아가는 방식으로 접근하였으나, 타임아웃에 걸렸습니다. 구글링하여 투 포인터와 비슷해 보이는 이분탐색을 사용하여 풀이하였습니다. 


### 4. 12015 가장 긴 증가하는 부분 수열 2
전에 풀었던 LCS 문제와 비슷하게 전개해보려 하였으나, dp리스트를 사용하여 하는 풀이는 n^2 시간복잡도를 가지기 때문에, 구글링하여 이분탐색 기법으로 풀었습니다. 이분탐색 기법이 투 포인터와 비슷해보여 활용도가 높을 것 같습니다.

## 🙏 같이 논의해보고 싶은 것 
파스칼 역삼각형 어케했누..
