### PR TITLE
[20230727] 손영진 문제 풀이

### DIFF
--- a/ByteAurora/20230727/1303.py
+++ b/ByteAurora/20230727/1303.py
@@ -1,0 +1,58 @@
+import sys
+from collections import deque
+
+directions = [(0, 1),  # RIGHT
+              (1, 0),  # DOWN
+              (0, -1),  # LEFT
+              (-1, 0)]  # UP
+
+
+def count_adjacent_soldiers(game_map, width, height, y, x, checked_positions):
+    queue = deque([(y, x)])
+    checked_positions[y][x] = True
+    count = 1
+
+    while queue:
+        y, x = queue.popleft()
+
+        for y_direction, x_direction in directions:
+            new_x = x + x_direction
+            new_y = y + y_direction
+
+            if 0 <= new_x < width and 0 <= new_y < height and \
+                    not checked_positions[new_y][new_x] and \
+                    game_map[new_y][new_x] == game_map[y][x]:
+                queue.append((new_y, new_x))
+                checked_positions[new_y][new_x] = True
+                count += 1
+
+    return count
+
+
+def calculate_army_power(width, height, game_map):
+    checked_positions = [[False] * width for _ in range(height)]
+
+    my_army_power = 0
+    enemy_army_power = 0
+
+    for y in range(height):
+        for x in range(width):
+            if not checked_positions[y][x]:
+                group_member = count_adjacent_soldiers(game_map, width, height, y, x, checked_positions)
+                if game_map[y][x] == 'W':
+                    my_army_power += group_member ** 2
+                elif game_map[y][x] == 'B':
+                    enemy_army_power += group_member ** 2
+
+    return my_army_power, enemy_army_power
+
+
+width, height = map(int, sys.stdin.readline().split())
+game_map = []
+
+for _ in range(height):
+    game_map.append(list(sys.stdin.readline().strip()))
+
+army_power = calculate_army_power(width, height, game_map)
+
+print(army_power[0], army_power[1])

--- a/ByteAurora/20230727/1393.py
+++ b/ByteAurora/20230727/1393.py
@@ -1,0 +1,28 @@
+import math
+import sys
+
+def get_distance(point1, point2):
+    return math.sqrt((point1[0] - point2[0])**2 + (point1[1] - point2[1])**2)
+
+def find_best_position(terminal_x, terminal_y, train_x, train_y, train_x_speed, train_y_speed):
+    gcd = math.gcd(train_x_speed, train_y_speed)
+    train_x_speed = train_x_speed // gcd
+    train_y_speed = train_y_speed // gcd
+    min_distance = get_distance((train_x, train_y), (terminal_x, terminal_y))
+
+    while True:
+        new_distance = get_distance((train_x, train_y), (terminal_x, terminal_y))
+
+        if new_distance > min_distance:
+            return train_x - train_x_speed, train_y - train_y_speed
+        else:
+            min_distance = new_distance
+
+        train_x += train_x_speed
+        train_y += train_y_speed
+
+terminal_x, terminal_y = map(int, sys.stdin.readline().strip().split())
+train_x, train_y, train_x_speed, train_y_speed = map(int, sys.stdin.readline().strip().split())
+
+result = find_best_position(terminal_x, terminal_y, train_x, train_y, train_x_speed, train_y_speed)
+print(result[0], result[1])

--- a/ByteAurora/20230727/14889.py
+++ b/ByteAurora/20230727/14889.py
@@ -1,0 +1,33 @@
+from itertools import combinations
+import sys
+
+
+def get_ability_difference(synergy_map, team1, team2):
+    def calculate_ability(team):
+        return sum(synergy_map[i - 1][j - 1] + synergy_map[j - 1][i - 1] for i, j in combinations(team, 2))
+
+    return abs(calculate_ability(team1) - calculate_ability(team2))
+
+
+def get_min_ability_difference(player_count, synergy_map):
+    min_ability_difference = float('inf')
+
+    players = range(1, player_count + 1)
+    team1_list = list(combinations(range(1, player_count + 1), player_count // 2))
+    team1_list = team1_list[:len(team1_list) // 2]
+
+    for team1 in team1_list:
+        team2 = [player for player in players if player not in team1]
+
+        ability_difference = get_ability_difference(synergy_map, team1, team2)
+
+        if ability_difference < min_ability_difference:
+            min_ability_difference = ability_difference
+
+    return min_ability_difference
+
+
+player_count = int(sys.stdin.readline())
+synergy_map = [list(map(int, sys.stdin.readline().split())) for _ in range(player_count)]
+
+print(get_min_ability_difference(player_count, synergy_map))


### PR DESCRIPTION
## 🔖 푼 문제들 
### 1. 1303 전쟁 - 전투
deque, bfs를 이용한 방식으로 해결. 모든 영역에 대해 탐색을 하되, 이미 탐색한 영역인지 확인하는 checked_positions를 이용해서 중복된 연산이 이루어지지 않도록 함. 


### 2. 1393 음하철도 구구팔
뭔가 수학적으로 풀어도 어떻게 더 나은 방법이 있을 것 같긴한데.. 머리가 안되서 그냥 현재 열차 위치부터 주어진 방향대로 가면서 `다음 열차 위치와 정류장 사이의 거리`가 `이전 열차 위치와 정류장 사이의 거리`보다 커지기 전까지 최소값을 갱신시키는 방식으로 구현했음. 그리고 정수 좌표만 해당되고 연속적이여야 하기 때문에(무조건 1초 단위로 이동하는게 아님) X, Y의 증가량의 최대공약수로 나눈 만큼씩 한 사이클당 이동하는 방식으로 구현.


### 3. 1450 냅색문제
하는중


### 4. 14889 스타트와 링크
combinations만 잘 활용하면 쉽게 풀 수 있음. 그리고 반환된 조합 중 절반의 조합만 확인하는 등의 로직을 추가해서 최적화할 수 있음.


## 🙏 같이 논의해보고 싶은 것 


